### PR TITLE
Use the project-specific Arrays class where appropriate

### DIFF
--- a/src/main/java/com/jakewharton/Arrays.java
+++ b/src/main/java/com/jakewharton/Arrays.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Array;
 /* From java.util.Arrays */
 class Arrays {
     @SuppressWarnings("unchecked")
-    private static <T> T[] copyOfRange(T[] original, int start, int end) {
+    static <T> T[] copyOfRange(T[] original, int start, int end) {
         int originalLength = original.length; // For exception priority compatibility.
         if (start > end) {
             throw new IllegalArgumentException();

--- a/src/main/java/com/jakewharton/DiskLruCache.java
+++ b/src/main/java/com/jakewharton/DiskLruCache.java
@@ -32,7 +32,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -885,7 +884,7 @@ public final class DiskLruCache implements Closeable {
         }
 
         private IOException invalidLengths(String[] strings) throws IOException {
-            throw new IOException("unexpected journal line: " + Arrays.toString(strings));
+            throw new IOException("unexpected journal line: " + java.util.Arrays.toString(strings));
         }
 
         public File getCleanFile(int i) {


### PR DESCRIPTION
It looks like you copied the [Arrays.copyOfRange](https://github.com/JakeWharton/DiskLruCache/blob/master/src/main/java/com/jakewharton/Arrays.java#L8) method to keep pre-gingerbread compatibility, but forgot to reference the new class. This pull request fixes that.
