### PR TITLE
Add getLength method to Snapshot

### DIFF
--- a/src/main/java/com/jakewharton/DiskLruCache.java
+++ b/src/main/java/com/jakewharton/DiskLruCache.java
@@ -394,7 +394,7 @@ public final class DiskLruCache implements Closeable {
             executorService.submit(cleanupCallable);
         }
 
-        return new Snapshot(key, entry.sequenceNumber, ins);
+        return new Snapshot(key, entry.sequenceNumber, ins, entry.lengths);
     }
 
     /**
@@ -635,11 +635,13 @@ public final class DiskLruCache implements Closeable {
         private final String key;
         private final long sequenceNumber;
         private final InputStream[] ins;
+        private final long[] lengths;
 
-        private Snapshot(String key, long sequenceNumber, InputStream[] ins) {
+        private Snapshot(String key, long sequenceNumber, InputStream[] ins, long[] lengths) {
             this.key = key;
             this.sequenceNumber = sequenceNumber;
             this.ins = ins;
+            this.lengths = lengths;
         }
 
         /**
@@ -663,6 +665,13 @@ public final class DiskLruCache implements Closeable {
          */
         public String getString(int index) throws IOException {
             return inputStreamToString(getInputStream(index));
+        }
+
+        /**
+         * Returns the byte length of the value for {@code index}.
+         */
+        public long getLength(int index) {
+            return lengths[index];
         }
 
         public void close() {

--- a/src/test/java/com/jakewharton/DiskLruCacheTest.java
+++ b/src/test/java/com/jakewharton/DiskLruCacheTest.java
@@ -135,7 +135,9 @@ public final class DiskLruCacheTest extends TestCase {
 
         DiskLruCache.Snapshot snapshot = cache.get("k1");
         assertEquals("ABC", snapshot.getString(0));
+        assertEquals(3, snapshot.getLength(0));
         assertEquals("DE", snapshot.getString(1));
+        assertEquals(2, snapshot.getLength(1));
     }
 
     public void testReadAndWriteEntryAcrossCacheOpenAndClose() throws Exception {
@@ -148,7 +150,9 @@ public final class DiskLruCacheTest extends TestCase {
         cache = DiskLruCache.open(cacheDir, appVersion, 2, Integer.MAX_VALUE);
         DiskLruCache.Snapshot snapshot = cache.get("k1");
         assertEquals("A", snapshot.getString(0));
+        assertEquals(1, snapshot.getLength(0));
         assertEquals("B", snapshot.getString(1));
+        assertEquals(1, snapshot.getLength(1));
         snapshot.close();
     }
 
@@ -254,12 +258,15 @@ public final class DiskLruCacheTest extends TestCase {
 
         DiskLruCache.Snapshot snapshot2 = cache.get("k1");
         assertEquals("CCcc", snapshot2.getString(0));
+        assertEquals(4, snapshot2.getLength(0));
         assertEquals("DDdd", snapshot2.getString(1));
+        assertEquals(4, snapshot2.getLength(1));
         snapshot2.close();
 
         assertEquals('a', inV1.read());
         assertEquals('a', inV1.read());
         assertEquals("BBbb", snapshot1.getString(1));
+        assertEquals(4, snapshot1.getLength(1));
         snapshot1.close();
     }
 
@@ -428,7 +435,9 @@ public final class DiskLruCacheTest extends TestCase {
 
         DiskLruCache.Snapshot snapshot = cache.get("k1");
         assertEquals("C", snapshot.getString(0));
+        assertEquals(1, snapshot.getLength(0));
         assertEquals("B", snapshot.getString(1));
+        assertEquals(1, snapshot.getLength(1));
         snapshot.close();
     }
 
@@ -911,7 +920,9 @@ public final class DiskLruCacheTest extends TestCase {
     private void assertValue(String key, String value0, String value1) throws Exception {
         DiskLruCache.Snapshot snapshot = cache.get(key);
         assertEquals(value0, snapshot.getString(0));
+        assertEquals(value0.length(), snapshot.getLength(0));
         assertEquals(value1, snapshot.getString(1));
+        assertEquals(value1.length(), snapshot.getLength(1));
         assertTrue(getCleanFile(key, 0).exists());
         assertTrue(getCleanFile(key, 1).exists());
         snapshot.close();


### PR DESCRIPTION
This pull request adds a getLength method to the Snapshot class. This lets you fetch the length of the associated stream without having to do something crazy like read the whole this. This is useful for me in the case where I'm sending the stream to a client and I need to send a `Content-Length` header before the data. The tests have been updated as well.
