### PR TITLE
Track redundant ops when opening the cache.

### DIFF
--- a/src/main/java/com/jakewharton/DiskLruCache.java
+++ b/src/main/java/com/jakewharton/DiskLruCache.java
@@ -244,13 +244,16 @@ public final class DiskLruCache implements Closeable {
                         + magic + ", " + version + ", " + valueCountString + ", " + blank + "]");
             }
 
+            int lineCount = 0;
             while (true) {
                 try {
                     readJournalLine(reader.readLine());
+                    lineCount++;
                 } catch (EOFException endOfJournal) {
                     break;
                 }
             }
+            redundantOpCount = lineCount - lruEntries.size();
         } finally {
             IoUtils.closeQuietly(reader);
         }


### PR DESCRIPTION
See https://github.com/JakeWharton/DiskLruCache/issues/28
