### PR TITLE
Avoid throwing an exception trying to delete that which does not exist.

### DIFF
--- a/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
+++ b/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
@@ -586,8 +586,7 @@ public final class DiskLruCache implements Closeable {
 
     for (int i = 0; i < valueCount; i++) {
       File file = entry.getCleanFile(i);
-      boolean fileExisted = file.exists();
-      if (fileExisted && !file.delete()) {
+      if (file.exists() && !file.delete()) {
         throw new IOException("failed to delete " + file);
       }
       size -= entry.lengths[i];


### PR DESCRIPTION
For some unknown reason, when you have a hundreds of thousands of clients a day using the DiskLruCache API on Android when some of them make use of trimToSize() (when tryng to flush(), or delete() the cache) they end up having the exception thrown by remove() because it tries to delete a file which does not exist.

I'm not sure what the cause is, but It's as if something is removing the file for that key and the cache doesn't have a chance to know about it, maybe it's a synchronization issue,
maybe the file gets deleted by an external entity at the wrong time (and the phone is turned off, or the process is force closed at the wrong moment) and the cache thinks it still has a key that needs to be pruned. The result is that the cache can't never finish doing trimToSize()
(which is called when trying to flush() or delete()), so you can't never even delete the cache
unless you do it by force not using this API wiping out the entire directory and re-creating it.

When this happens, the whole cache becomes unusable, we've found instances where the cache files are months old thanks to this issue.
