### PR TITLE
Added contains() method

### DIFF
--- a/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
+++ b/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
@@ -395,17 +395,12 @@ public final class DiskLruCache implements Closeable {
       throw new IOException();
     }
   }
-  
+
   public boolean contains(String key) {
     checkNotClosed();
     validateKey(key);
     Entry entry = lruEntries.get(key);
-    if (entry == null) {
-      return false;
-    }
-    else {
-        return true;
-    }
+    return (entry != null);
   }
 
   /**


### PR DESCRIPTION
This is a much faster way of checking if a given key exists in the cache.

In a demanding use-case, scrolling very quickly, where every item in a ListView must check to see if it's object's key exists in the DiskCache:
Some basic profiling showed this method taking **~3ms** vs using `get( key )` taking on average **~70ms**. I believe this is because `get()` is synchronized.

It should be safe to use `contains()` unsynchronized like this.

This addresses issue #54
