### PR TITLE
Replaced synchronize's with ReentrantReadWriteLock & added contains() method

### DIFF
--- a/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
+++ b/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
@@ -417,17 +417,14 @@ public final class DiskLruCache implements Closeable {
 
   public boolean contains(String key) {
     readLock.lock();
-    boolean doesContain = false;
     try {
       checkNotClosed();
       validateKey(key);
       Entry entry = lruEntries.get(key);
-      doesContain = (entry != null);
+      return (entry != null);
     } finally {
       readLock.unlock();
     }
-
-    return doesContain;
   }
 
   /**


### PR DESCRIPTION
This PR removes all synchronized statements in favor of a `ReentrantReadWriteLock`. This allows read operations to not block each other, but write operations to block everything (_the way synchronized was working previously_).

With the addition of a simple `contains()` method, it is now super cheap to check if an image exists in the cache.
