### PR TITLE
Unit test temp dir now properly cleaned up

### DIFF
--- a/src/test/java/com/jakewharton/disklrucache/DiskLruCacheTest.java
+++ b/src/test/java/com/jakewharton/disklrucache/DiskLruCacheTest.java
@@ -51,7 +51,7 @@ public final class DiskLruCacheTest {
   @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
   @Before public void setUp() throws Exception {
-    cacheDir = tempDir.newFolder( "DiskLruCacheTest" );
+    cacheDir = tempDir.newFolder("DiskLruCacheTest");
     journalFile = new File(cacheDir, JOURNAL_FILE);
     journalBkpFile = new File(cacheDir, JOURNAL_FILE_BACKUP);
     for (File file : cacheDir.listFiles()) {


### PR DESCRIPTION
Uses a test rule to ensure the temp directory is cleaned up as soon as
the test is completed. This prevents potential problems with re-running
the test and having an old directory present.
