### PR TITLE
Fix off by one index error in tests.

### DIFF
--- a/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
+++ b/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
@@ -766,6 +766,11 @@ public final class DiskLruCache implements Closeable {
      * IOExceptions.
      */
     public OutputStream newOutputStream(int index) throws IOException {
+      if (index < 0 || index >= valueCount) {
+        throw new IllegalArgumentException("Expected index " + index + " to "
+                + "be greater than 0 and less than the maximum value count "
+                + "of " + valueCount);
+      }
       synchronized (DiskLruCache.this) {
         if (entry.currentEditor != this) {
           throw new IllegalStateException();

--- a/src/test/java/com/jakewharton/disklrucache/DiskLruCacheTest.java
+++ b/src/test/java/com/jakewharton/disklrucache/DiskLruCacheTest.java
@@ -864,9 +864,9 @@ public final class DiskLruCacheTest {
     set("a", "a", "a");
     set("b", "b", "b");
     DiskLruCache.Editor a = cache.get("a").edit();
-    a.set(1, "a1");
+    a.set(0, "a1");
     FileUtils.deleteDirectory(cacheDir);
-    a.set(2, "a2");
+    a.set(1, "a2");
     a.commit();
     assertThat(cache.get("a")).isNull();
   }


### PR DESCRIPTION
The index should start at 0, this is just a small bug in the test that is hidden by the lack of input validation in the Editor and the current implementation of getCleanFile/getDirtyFile.
