### PR TITLE
Update keys length in regex in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Disk LRU Cache
 
 A cache that uses a bounded amount of space on a filesystem. Each cache entry
 has a string key and a fixed number of values. Each key must match the regex
-`[a-z0-9_-]{1,64}`.  Values are byte sequences, accessible as streams or files.
+`[a-z0-9_-]{1,120}`.  Values are byte sequences, accessible as streams or files.
 Each value must be between `0` and `Integer.MAX_VALUE` bytes in length.
 
 The cache stores its data in a directory on the filesystem. This directory must


### PR DESCRIPTION
Since https://github.com/JakeWharton/DiskLruCache/pull/65/files it is 120 bytes rather than 64.