### PR TITLE
Avoid IOExceptions in delete() when the cache dir is deleted externally.

### DIFF
--- a/src/main/java/com/jakewharton/disklrucache/Util.java
+++ b/src/main/java/com/jakewharton/disklrucache/Util.java
@@ -50,6 +50,9 @@ final class Util {
    * could not be deleted, or if {@code dir} is not a readable directory.
    */
   static void deleteContents(File dir) throws IOException {
+    if (!dir.exists()) {
+      return;
+    }
     File[] files = dir.listFiles();
     if (files == null) {
       throw new IOException("not a readable directory: " + dir);

--- a/src/test/java/com/jakewharton/disklrucache/DiskLruCacheTest.java
+++ b/src/test/java/com/jakewharton/disklrucache/DiskLruCacheTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.InputStream;
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -883,6 +884,42 @@ public final class DiskLruCacheTest {
   @Test public void aggressiveClearingHandlesRead() throws Exception {
     FileUtils.deleteDirectory(cacheDir);
     assertThat(cache.get("a")).isNull();
+  }
+
+  @Test public void deleteAfterCacheDirectoryIsDeletedExternallyDoesNotThrow()
+      throws IOException {
+    FileUtils.deleteDirectory(cacheDir);
+    cache.delete();
+  }
+
+  @Test public void deleteWithNotReadableCacheDirectoryThowsIOException()
+      throws IOException {
+    try {
+      if (!cacheDir.setReadable(false)) {
+        fail("Unable to set writable on: " + cacheDir);
+      }
+      cache.delete();
+      fail("Expected delete to throw");
+    } catch (IOException e) {
+      // Expected.
+    } finally {
+       cacheDir.setReadable(true);
+    }
+  }
+
+  @Test public void deleteWithNotWritableCacheDirectoryThowsIOException()
+      throws IOException {
+    try {
+      if (!cacheDir.setWritable(false)) {
+        fail("Unable to set writable on: " + cacheDir);
+      }
+      cache.delete();
+      fail("Expected delete to throw");
+    } catch (IOException e) {
+      // Expected.
+    } finally {
+       cacheDir.setWritable(true);
+    }
   }
 
   private void assertJournalEquals(String... expectedBodyLines) throws Exception {


### PR DESCRIPTION
``File#listFiles()`` will return ``null`` if the directory has been deleted. This 
scenario isn’t totally far fetched because it’s fairly common for 
Android developers to place their disk caches in the Android application 
cache directory. The cache directory can be cleared at any time by the 
system, including while the app is open, which in turn can cause 
unexpected IOExceptions when ``delete()`` is called.

See https://github.com/bumptech/glide/issues/2465 for additional 
context.